### PR TITLE
Update cui-standard.css to fix display issue with 9410R

### DIFF
--- a/static/css/cui-standard.css
+++ b/static/css/cui-standard.css
@@ -3624,7 +3624,6 @@ html ::-webkit-scrollbar-thumb:hover {
 }
 .cui .content {
  flex:1;
- overflow:hidden;
  min-height:100vh;
  -webkit-overflow-scrolling:touch
 }


### PR DESCRIPTION
When displaying a Cisco 9410R Switch  in the switchView.html page, the right scroll bar is not present and you only see the first 2 blades.  You can see it if you unzoom to 25%...

By removing the  overflow:hidden in the section .cui .content of the cui-standard.css file the scroll bar comes back.

Regards,