### PR TITLE
create a dedicated backend function to determine which parse command …

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -36,8 +36,6 @@ voucher_group_B = "BBB-Vouchers"
 voucher_group_C = "CCC-Vouchers"
 timeout = 15 * 60  # in minutes
 batch = 50
-parse_command = "authentication session"  # 'access-session' or 'authentication session'
-# Some old switches do not support 'authentication session'
 
 auth = HTTPBasicAuth(ise_user, ise_password)
 async_auth = BasicAuth(ise_user, ise_password)
@@ -332,8 +330,26 @@ def check_ise_auth_status(mac_address: str):
 ######       End of ISE functions      ######
 
 
+def get_parse_command(device) -> str:
+    """
+    This function will determine which command should be used when getting
+    authentication sessions on the device.
+
+    Returns a string, one of the following values:
+      - access-session
+      - authentication session
+    """
+    Testcli=""
+    Testcli = device.execute(f"show ?")
+    pp(f"{Testcli}")
+
+    if "authentication" not in Testcli:
+        return 'access-session'
+    else:
+        return 'authentication session'
+
+
 def get_device_ports(device_ip: str):
-    global parse_command
     """
     This function will retrieve the list of interfaces on a given NAD/Switch,
     the list of authentication sessions on that switch, and return a dictionary
@@ -392,16 +408,8 @@ def get_device_ports(device_ip: str):
         pp(f"[red]ERROR: Problem connecting to {device_ip}...")
         return [f"ERROR: Problem connecting to {device_ip}..."]
     # Get authentication sessions
-    Testcli=""
-    Testcli = device.execute(f"show ?")
-    pp(f"{Testcli}")
-
-    if "authentication" not in Testcli:
-        parse_command = 'access-session'
-    else:
-        parse_command = 'authentication session'
-
     try:
+        parse_command = get_parse_command(device)
         auth_sessions = device.parse(f"show {parse_command}")
     except SchemaEmptyParserError:
         pp(f"[red]ERROR: No access sessions on {device_ip}.")
@@ -474,6 +482,7 @@ def get_device_auth_sessions(device_ip: str):
         return [f"ERROR: Problem connecting to {device_ip}..."]
     # Get authentication sessions
     try:
+        parse_command = get_parse_command(device)
         auth_sessions = device.parse(f"show {parse_command}")
     except SchemaEmptyParserError:
         pp(f"[red]ERROR: No access sessions on {device_ip}.")
@@ -603,6 +612,7 @@ def get_port_auth_sessions(device_ip: str, interface: str):
         return [f"ERROR: Problem connecting to {device_ip}..."]
     # Get authentication sessions
     try:
+        parse_command = get_parse_command(device)
         auth_sessions = device.parse(f"show {parse_command}")
     except SchemaEmptyParserError:
         pp(f"[red]ERROR: No access sessions on {device_ip}.")
@@ -705,7 +715,8 @@ def clear_port_auth_sessions(device_ip: str, interface: str):
         return [f"ERROR: Problem connecting to {device_ip}..."]
     # Clear authentication sessions
     try:
-        device.execute(f"clear authentication session interface {interface}")
+        parse_command = get_parse_command(device)
+        device.execute(f"clear {parse_command} interface {interface}")
     except:
         pp(f"[red]ERROR: Problem parsing information from {device_ip}.")
         device.disconnect()


### PR DESCRIPTION
I've removed the global "parse_command" variable and created a dedicated function to determine which command to use whenever we log into the device.

In a mixed environment with old and newer devices, having the global variable only updated when we hit /switchView -> get_device_ports() caused issues for us.  If we started at /deviceQuery -> get_device_auth_sessions() or attempted to revoke an existing voucher there was no guarantee we would use the correct parse command.

I'm open to adding caching to the new function I created to cache the parse_command by device if needed, that will prevent from having to run "show ?" every single time we log into a device.

I've also added the "parse_command" to the clear_port_auth_sessions() function because it was hard coded to use "authentication session".