### PR TITLE
Fix EndpointQuery Error when endpoint auth failed

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -290,9 +290,18 @@ def check_ise_auth_status(mac_address: str):
                 status_details["Username"] = status["authStatusOutputList"][
                     "authStatusList"
                 ]["authStatusElements"]["user_name"]
-                status_details["IdentityGroup"] = status["authStatusOutputList"][
+                 # Add identity group, if available
+                if (
+                    "identity_group"
+                    in status["authStatusOutputList"]["authStatusList"][
+                        "authStatusElements"
+                    ].keys()
+                ):
+                     status_details["IdentityGroup"] = status["authStatusOutputList"][
                     "authStatusList"
-                ]["authStatusElements"]["identity_group"]
+                    ]["authStatusElements"]["identity_group"]
+                else:
+                    status_details["IdentityGroup"] = "N/A"
                 # Add IP address, if available
                 if "framed_ip_address" in status["authStatusOutputList"][
                     "authStatusList"]["authStatusElements"].keys():


### PR DESCRIPTION
Reason: 'identity_group' will not be returned from ISE if endpoint auth is Fail without allocated a identity group, which will cause error in frontend if it's not assigned a value.

Auth fail device: Dell Desktop
Auth method: dot1x
Auth fail reason: 12503 Failed to negotiate EAP because EAP-TLS not enabled in Allowed Protocols

Resolution: Will return 'N/A' if endpoint auth failed